### PR TITLE
Include node_modules to parcel bundle

### DIFF
--- a/services/a/serverless.yml
+++ b/services/a/serverless.yml
@@ -1,11 +1,15 @@
 service: a
 
+custom:
+  parcel:
+    bundleNodeModules: true
+
 plugins:
   - serverless-plugin-parcel
 
 provider:
- name: aws
- runtime: nodejs12.x
+  name: aws
+  runtime: nodejs12.x
 
 functions:
   func-a:

--- a/services/b/serverless.yml
+++ b/services/b/serverless.yml
@@ -1,11 +1,15 @@
 service: b
 
+custom:
+  parcel:
+    bundleNodeModules: true
+
 plugins:
   - serverless-plugin-parcel
 
 provider:
- name: aws
- runtime: nodejs12.x
+  name: aws
+  runtime: nodejs12.x
 
 functions:
   func-b:


### PR DESCRIPTION
By default Parcel will not bundle `dependencies` from `package.json` when the target is set to `node`. 